### PR TITLE
Added logic to skip firstLine response header if HTTP 2.0

### DIFF
--- a/charles_to_postman.py
+++ b/charles_to_postman.py
@@ -177,10 +177,14 @@ def convert_charles_to_postman(charles_node):
     status_code = c_response['status']
     p_response = {'name': path, 'originalRequest': p_request,
                   'code': status_code, 'header': [], 'cookie': []}
-    p_status = c_response['header']['firstLine'].replace(
-        '%s %d ' % (protocol, status_code), '')
+    try:
+        p_status = c_response['header']['firstLine'].replace(
+            '%s %d ' % (protocol, status_code), '')
 
-    p_response['status'] = p_status
+        p_response['status'] = p_status
+    except KeyError:
+        pass
+        
     for header in c_response['header']['headers']:
         p_response['header'].append(
             {'key': header['name'], 'value': header['value']})


### PR DESCRIPTION
This PR is an attempt to support HTTP/1.1 and HTTP/2.0 requests.

The HTTP 1.1 version of the response header begins with the format `<HTTP Version><response code><status>` (Ex. 'HTTP/1.1 200 OK' ).
When exporting a Charles JSON Session File this first line is stored under the `firstLine` key.  The script is explicitly searching for the `firstLine` key when doing its processing of the Charles JSON Session File.
I noticed that HTTP 2.0 response headers do not begin with this line so the script returns a `KeyError` when trying to process a Charles JSON Session File that has HTTP 2.0 requests.
I added a try/except block to skip this processing if the `firstLine` key does not exist 